### PR TITLE
Validate NOTION_TOKEN environment variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,9 @@ import { getFileName, getPageTitle } from "./helpers";
 dotenv.config();
 
 async function main() {
-  if (process.env.NOTION_TOKEN === "")
-    throw Error("The NOTION_TOKEN environment vairable is not set.");
+  // NOTION_TOKEN is required to authenticate with Notion's API
+  if (!process.env.NOTION_TOKEN)
+    throw Error("The NOTION_TOKEN environment variable is not set.");
   const config = await loadConfig();
   console.info("[Info] Config loaded ");
 


### PR DESCRIPTION
## Summary
- Fail fast when `NOTION_TOKEN` is absent
- Clarify error messaging for missing `NOTION_TOKEN`
- Document the requirement for `NOTION_TOKEN` to authenticate with Notion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ac153c55c8327939de968132b31fa