### PR TITLE
refactor: use public notion types

### DIFF
--- a/functions/api.ts
+++ b/functions/api.ts
@@ -1,5 +1,5 @@
 import { Client, isFullBlock, isFullPage } from "@notionhq/client";
-import { BlockObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import type { BlockObjectResponse } from "@notionhq/client";
 interface Env {
   KV: KVNamespace;
   NOTION_TOKEN?: string;

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,4 +1,4 @@
-import { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import type { PageObjectResponse } from "@notionhq/client";
 import fs from "fs";
 import path from "path";
 import fm from "front-matter";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,5 @@
 import { Client, isFullPage } from "@notionhq/client";
-import { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import type { PageObjectResponse } from "@notionhq/client";
 
 export function getPageTitle(page: PageObjectResponse): string {
   const title = page.properties.Name ?? page.properties.title;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import { Client, isFullPage, iteratePaginatedAPI } from "@notionhq/client";
+import { Client, isFullPage, iteratePaginatedAPI, isFullPageOrDatabase } from "@notionhq/client";
 import dotenv from "dotenv";
 import fs from "fs-extra";
 import { savePage } from "./render";
 import { loadConfig } from "./config";
 import { getAllContentFiles } from "./file";
-import { isFullPageOrDatabase } from "@notionhq/client/build/src/helpers";
 import { getFileName, getPageTitle } from "./helpers";
 
 dotenv.config();

--- a/src/markdown/md.ts
+++ b/src/markdown/md.ts
@@ -1,16 +1,18 @@
 import { markdownTable } from "markdown-table";
-import {
-  AudioBlockObjectResponse,
+import type {
   EquationRichTextItemResponse,
   MentionRichTextItemResponse,
-  PdfBlockObjectResponse,
   RichTextItemResponse,
   TextRichTextItemResponse,
-  VideoBlockObjectResponse,
-} from "@notionhq/client/build/src/api-endpoints";
+  BlockObjectResponse,
+} from "@notionhq/client";
+import { Client } from "@notionhq/client";
 import { CalloutIcon } from "./types";
 import { getPageRelrefFromId } from "./notion";
-import { Client } from "@notionhq/client";
+
+type AudioBlockObjectResponse = Extract<BlockObjectResponse, { type: "audio" }>;
+type PdfBlockObjectResponse = Extract<BlockObjectResponse, { type: "pdf" }>;
+type VideoBlockObjectResponse = Extract<BlockObjectResponse, { type: "video" }>;
 export const inlineCode = (text: string) => {
   return `\`${text}\``;
 };

--- a/src/markdown/notion-to-md.ts
+++ b/src/markdown/notion-to-md.ts
@@ -1,8 +1,8 @@
 import { Client, isFullBlock } from "@notionhq/client";
-import {
+import type {
   GetBlockResponse,
   RichTextItemResponse,
-} from "@notionhq/client/build/src/api-endpoints";
+} from "@notionhq/client";
 import { CustomTransformer, MdBlock, NotionToMarkdownOptions } from "./types";
 import * as md from "./md";
 import { getBlockChildren, getPageRelrefFromId } from "./notion";

--- a/src/markdown/notion.ts
+++ b/src/markdown/notion.ts
@@ -1,9 +1,9 @@
 import { Client, isFullPage } from "@notionhq/client";
-import {
+import type {
   GetBlockResponse,
   ListBlockChildrenResponse,
   PageObjectResponse,
-} from "@notionhq/client/build/src/api-endpoints";
+} from "@notionhq/client";
 import { plainText } from "./md";
 
 export const getBlockChildren = async (

--- a/src/markdown/types.ts
+++ b/src/markdown/types.ts
@@ -1,4 +1,4 @@
-import { GetBlockResponse } from "@notionhq/client/build/src/api-endpoints";
+import type { GetBlockResponse } from "@notionhq/client";
 import { Client } from "@notionhq/client";
 
 export interface NotionToMarkdownOptions {

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra";
 import { Client, isFullUser, iteratePaginatedAPI } from "@notionhq/client";
-import { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import type { PageObjectResponse } from "@notionhq/client";
 import { NotionToMarkdown } from "./markdown/notion-to-md";
 import YAML from "yaml";
 import { sh } from "./sh";


### PR DESCRIPTION
## Summary
- replace internal `@notionhq/client` imports with public type imports
- drop `build/src/helpers` usage
- add local block type aliases for audio, pdf, and video blocks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ac1661a648327add91dd3c4aad8e5