### PR TITLE
fix gitalk param casing

### DIFF
--- a/themes/github-style/layouts/partials/gitalk.html
+++ b/themes/github-style/layouts/partials/gitalk.html
@@ -43,12 +43,12 @@
 <script src="https://unpkg.com/gitalk@latest/dist/gitalk.min.js"></script>
 <script>
   const gitalk = new Gitalk({
-    clientID: '{{ .Site.Params.Gitalk.clientID }}',
-    clientSecret: '{{ .Site.Params.Gitalk.clientSecret }}',
-    repo: '{{ .Site.Params.Gitalk.repo }}',
-    owner: '{{ .Site.Params.Gitalk.owner }}',
-    admin: ['{{ .Site.Params.Gitalk.owner }}'],
-    id: eval({{ .Site.Params.Gitalk.id }}), // Ensure uniqueness and length less than 50
+    clientID: '{{ .Site.Params.gitalk.clientID }}',
+    clientSecret: '{{ .Site.Params.gitalk.clientSecret }}',
+    repo: '{{ .Site.Params.gitalk.repo }}',
+    owner: '{{ .Site.Params.gitalk.owner }}',
+    admin: ['{{ .Site.Params.gitalk.owner }}'],
+    id: eval({{ .Site.Params.gitalk.id }}), // Ensure uniqueness and length less than 50
     distractionFreeMode: false // Facebook-like distraction free mode
   });
   (function() {


### PR DESCRIPTION
## Summary
- fix Gitalk partial to reference lowercase gitalk params

## Testing
- `npm run build`
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689ac171342c8327b6b582beed7d6542