### PR TITLE
Remove eval from Gitalk ID configuration

### DIFF
--- a/themes/github-style/layouts/partials/gitalk.html
+++ b/themes/github-style/layouts/partials/gitalk.html
@@ -42,13 +42,15 @@
 </style>
 <script src="https://unpkg.com/gitalk@latest/dist/gitalk.min.js"></script>
 <script>
+  const rawGitalkId = '{{ .Site.Params.Gitalk.id | default "window.location.pathname" }}';
+  const gitalkId = rawGitalkId === "window.location.pathname" || rawGitalkId === "location.pathname" ? window.location.pathname : rawGitalkId;
   const gitalk = new Gitalk({
     clientID: '{{ .Site.Params.Gitalk.clientID }}',
     clientSecret: '{{ .Site.Params.Gitalk.clientSecret }}',
     repo: '{{ .Site.Params.Gitalk.repo }}',
     owner: '{{ .Site.Params.Gitalk.owner }}',
     admin: ['{{ .Site.Params.Gitalk.owner }}'],
-    id: eval({{ .Site.Params.Gitalk.id }}), // Ensure uniqueness and length less than 50
+    id: gitalkId, // Ensure uniqueness and length less than 50
     distractionFreeMode: false // Facebook-like distraction free mode
   });
   (function() {


### PR DESCRIPTION
## Summary
- Avoid `eval` by retrieving the Gitalk ID as a string and using `window.location.pathname` when requested.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ac3cc69208327b0d9d6a970e484d5