### PR TITLE
Sanitize file paths and use spawn for Hugo

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,10 +25,10 @@ export async function getCoverLink(
 }
 
 export function getFileName(title: string, page_id: string): string {
-  return (
-    title.replaceAll(" ", "-").replace(/--+/g, "-") +
-    "-" +
-    page_id.replaceAll("-", "") +
-    ".md"
-  );
+  const sanitizedTitle = title
+    .replace(/[\\/:*?"'<>|`]/g, "")
+    .replaceAll(" ", "-")
+    .replace(/--+/g, "-");
+  const sanitizedId = page_id.replaceAll("-", "");
+  return `${sanitizedTitle}-${sanitizedId}.md`;
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -3,11 +3,11 @@ import { Client, isFullUser, iteratePaginatedAPI } from "@notionhq/client";
 import { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { NotionToMarkdown } from "./markdown/notion-to-md";
 import YAML from "yaml";
-import { sh } from "./sh";
 import { DatabaseMount, PageMount } from "./config";
 import { getPageTitle, getCoverLink, getFileName } from "./helpers";
 import path from "path";
 import { getContentFile } from "./file";
+import { spawn } from "child_process";
 
 export async function renderPage(page: PageObjectResponse, notion: Client) {
   // load formatter config
@@ -156,11 +156,11 @@ export async function savePage(
   notion: Client,
   mount: DatabaseMount | PageMount,
 ) {
-  const postpath = path.join(
-    "content",
-    mount.target_folder,
+  const targetFolder = sanitizeFolder(mount.target_folder);
+  const initialFileName = sanitizeFileName(
     getFileName(getPageTitle(page), page.id),
   );
+  const postpath = path.join("content", targetFolder, initialFileName);
   const post = getContentFile(postpath);
   if (post && post.metadata.last_edited_time === page.last_edited_time) {
     console.info(`[Info] The post ${postpath} is up-to-date, skipped.`);
@@ -170,7 +170,34 @@ export async function savePage(
   console.info(`[Info] Updating ${postpath}`);
 
   const { title, pageString } = await renderPage(page, notion);
-  const fileName = getFileName(title, page.id);
-  await sh(`hugo new "${mount.target_folder}/${fileName}"`, false);
-  fs.writeFileSync(`content/${mount.target_folder}/${fileName}`, pageString);
+  const fileName = sanitizeFileName(getFileName(title, page.id));
+
+  await runHugoNew(`${targetFolder}/${fileName}`);
+  fs.writeFileSync(`content/${targetFolder}/${fileName}`, pageString);
+}
+
+function runHugoNew(target: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("hugo", ["new", target]);
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`hugo exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function sanitizeFolder(folder: string): string {
+  const normalized = path.posix.normalize(folder);
+  if (path.posix.isAbsolute(normalized) || normalized.startsWith("..")) {
+    throw new Error(`Invalid target folder: ${folder}`);
+  }
+  return normalized.replace(/["'`]/g, "");
+}
+
+function sanitizeFileName(name: string): string {
+  return path.posix.basename(name).replace(/["'`]/g, "");
 }


### PR DESCRIPTION
## Summary
- Sanitize target folder and post filename before invoking Hugo
- Use child_process spawn to call Hugo without shell parsing
- Strip quotes and unsafe characters from generated filenames

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ac3d12d988327a7a0d72e20738ea1