### PR TITLE
chore: typecheck functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "server": "hugo server -D --disableFastRender --noHTTPCache",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit --skipLibCheck -p functions/tsconfig.json",
     "build": "tsc",
     "format": "prettier --write src/**/*.ts"
   },
@@ -44,3 +44,4 @@
     "typescript": "^5.8.3"
   }
 }
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,8 +102,6 @@
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    "functions/**/*"
   ]
 }
+


### PR DESCRIPTION
## Summary
- allow functions to be type-checked by removing exclude
- run tsc over the functions directory during typecheck

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ac3d7e1ec8327bec570540a288ff9