### PR TITLE
Clarify page_url usage in Notion config

### DIFF
--- a/notion-hugo.config.ts
+++ b/notion-hugo.config.ts
@@ -4,7 +4,8 @@ const userConfig: UserConfig = {
     base_url: "https://blog.namuori.net",
     mount: {
         manual: true,
-        page_url: 'https://namuori00.notion.site/218dcd44779f80a0b5fcc7cffbc88959',
+        // page_url only applies when manual is false for automatic discovery
+        // page_url: 'https://namuori00.notion.site/218dcd44779f80a0b5fcc7cffbc88959',
         pages: [
             // {
             //     page_id: '<page_id>',


### PR DESCRIPTION
## Summary
- remove `page_url` from Notion mount config
- document that `page_url` is only used when `manual` is false

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ac3e097b08327a1c3eb2dfaafe39d