### PR TITLE
chore: update @notionhq/client to ^4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@notionhq/client": "^3.1.3",
+        "@notionhq/client": "^4.0.1",
         "dotenv": "^16.5.0",
         "front-matter": "^4.0.2",
         "fs-extra": "^11.3.0",
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@notionhq/client": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-3.1.3.tgz",
-      "integrity": "sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-4.0.1.tgz",
+      "integrity": "sha512-SdILqiiThECLR2KDUOvl4JqRaJWBwDYaEw/f0qu+G6rKN/QUCkaJ84vN5MgBw1yKsMAsKxBlDazs3Jw6vv2ikA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -880,9 +880,9 @@
       "optional": true
     },
     "@notionhq/client": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-3.1.3.tgz",
-      "integrity": "sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-4.0.1.tgz",
+      "integrity": "sha512-SdILqiiThECLR2KDUOvl4JqRaJWBwDYaEw/f0qu+G6rKN/QUCkaJ84vN5MgBw1yKsMAsKxBlDazs3Jw6vv2ikA=="
     },
     "@types/fs-extra": {
       "version": "11.0.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "HEIGE-PCloud",
   "dependencies": {
-    "@notionhq/client": "^3.1.3",
+    "@notionhq/client": "^4.0.1",
     "dotenv": "^16.5.0",
     "front-matter": "^4.0.2",
     "fs-extra": "^11.3.0",

--- a/src/markdown/md.ts
+++ b/src/markdown/md.ts
@@ -3,7 +3,6 @@ import type {
   EquationRichTextItemResponse,
   MentionRichTextItemResponse,
   RichTextItemResponse,
-  TextRichTextItemResponse,
   BlockObjectResponse,
 } from "@notionhq/client";
 import { Client } from "@notionhq/client";
@@ -13,6 +12,8 @@ import { getPageRelrefFromId } from "./notion";
 type AudioBlockObjectResponse = Extract<BlockObjectResponse, { type: "audio" }>;
 type PdfBlockObjectResponse = Extract<BlockObjectResponse, { type: "pdf" }>;
 type VideoBlockObjectResponse = Extract<BlockObjectResponse, { type: "video" }>;
+
+type TextRichText = Extract<RichTextItemResponse, { type: "text" }>;
 export const inlineCode = (text: string) => {
   return `\`${text}\``;
 };
@@ -128,7 +129,7 @@ export const equation = (expression: string) => {
   return `\\[${expression}\\]`;
 };
 
-function textRichText(text: TextRichTextItemResponse): string {
+function textRichText(text: TextRichText): string {
   const annotations = text.annotations;
   let content = text.text.content;
   if (annotations.bold) {


### PR DESCRIPTION
## Summary
- bump Notion SDK to ^4.0.1
- adjust markdown text handling for updated Notion types

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689acca01e688327852561d429f448f4