### PR TITLE
chore: upgrade dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@notionhq/client": "^3.1.3",
-        "dotenv": "^16.5.0",
+        "dotenv": "^17.2.1",
         "front-matter": "^4.0.2",
         "fs-extra": "^11.3.0",
         "markdown-table": "^3.0.4",
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -921,9 +921,9 @@
       }
     },
     "dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ=="
     },
     "esbuild": {
       "version": "0.25.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "HEIGE-PCloud",
   "dependencies": {
     "@notionhq/client": "^3.1.3",
-    "dotenv": "^16.5.0",
+    "dotenv": "^17.2.1",
     "front-matter": "^4.0.2",
     "fs-extra": "^11.3.0",
     "markdown-table": "^3.0.4",
@@ -44,4 +44,3 @@
     "typescript": "^5.8.3"
   }
 }
-


### PR DESCRIPTION
## Summary
- bump dotenv to ^17.2.1
- refresh lockfile

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `NOTION_TOKEN=foo npm start`

------
https://chatgpt.com/codex/tasks/task_e_689acca13a448327bbd3a0a044fd8163