### PR TITLE
chore: upgrade TypeScript to 5.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^22.15.29",
         "prettier": "^3.5.3",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=16",
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1049,9 +1049,9 @@
       }
     },
     "typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.15.29",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }
 


### PR DESCRIPTION
## Summary
- upgrade TypeScript dev dependency to 5.9.2
- update lockfile and reinstall packages

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689acca45b748327adfdde334e6c5878