### PR TITLE
ci: update git-auto-commit-action to v6.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ jobs:
           npm start
 
       - name: Commit updated content
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6.0.1
         with:
           commit_message: Sync content with Notion
 


### PR DESCRIPTION
## Summary
- chore(ci): update git-auto-commit-action to v6.0.1 in CD workflow

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_689acca4a8a4832792d23c9bd296c27a