### PR TITLE
feat: mount default content directory

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -50,6 +50,10 @@ pygmentsUseClasses = true
 
 # Hugo Mounts Configuration
 [[module.mounts]]
+source = "content"
+target = "content"
+
+[[module.mounts]]
 source = "content/About-218dcd44779f81169bcedf9476baf73b.md"
 target = "content/readme.md"
 


### PR DESCRIPTION
## Summary
- explicitly mount the full `content` directory in Hugo config
- keep custom `About` -> `readme.md` mount after the default mount

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ad22ffdd8832783a27af1df25ab57