### PR TITLE
Truncate summary in posts partial

### DIFF
--- a/themes/github-style/layouts/partials/posts.html
+++ b/themes/github-style/layouts/partials/posts.html
@@ -38,7 +38,7 @@
 
             <div>
               <div class="col-12 d-inline-block text-gray mb-2 pr-4">
-                {{ .Summary | safeHTML }}
+                {{ .Summary | plainify | truncate 150 | safeHTML }}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Truncate summaries in the GitHub-style posts partial to 150 characters after stripping HTML.

## Testing
- `hugo --minify`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689adae3763083278b21f3284cac509a