### PR TITLE
Use plain summary text in overview cards

### DIFF
--- a/themes/github-style/layouts/partials/overview.html
+++ b/themes/github-style/layouts/partials/overview.html
@@ -57,7 +57,10 @@
 
 
                 <div name="summary" class="pinned-item-desc text-gray text-small d-block mt-2 mb-3">
-                  {{ .Summary | safeHTML }}
+                  {{- .Summary | plainify | truncate 100 -}}
+                  {{- if .Truncated -}}
+                  <a href="{{ .Permalink }}">더보기</a>
+                  {{- end -}}
                 </div>
 
                 <p class="mb-0 f6 text-gray">


### PR DESCRIPTION
## Summary
- strip HTML tags in overview card summaries and truncate to 100 characters
- show "더보기" link for truncated summaries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a2c9d94684832da975083895c5d0a7