### PR TITLE
feat: add summary length config

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://blog.namuori.net"
 languageCode = "en-us"
 title = "나무오리"
 theme = "github-style"
+summaryLength = 30
 
 pygmentsCodeFences = true
 pygmentsUseClasses = true


### PR DESCRIPTION
## Summary
- add `summaryLength = 30` to global config to shorten card summaries

## Testing
- `npm run build`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_b_68a2c9dadd90832da14d2ec9b95ca8b1