### PR TITLE
Map Notion summary to front matter

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -118,6 +118,22 @@ export async function renderPage(page: PageObjectResponse, notion: Client) {
     }
   }
 
+  // unify summary/description fields
+  for (const key of Object.keys(frontMatter)) {
+    const lower = key.toLowerCase();
+    if (
+      (lower === "summary" || lower === "description") &&
+      typeof frontMatter[key] === "string"
+    ) {
+      const value = frontMatter[key] as string;
+      frontMatter.summary = value;
+      frontMatter.description = value;
+      if (key !== "summary" && key !== "description") {
+        delete frontMatter[key];
+      }
+    }
+  }
+
   // set default author
   if (frontMatter.authors == null) {
     try {


### PR DESCRIPTION
## Summary
- capture Notion page summary/description properties and map them to `description` and `summary` in generated front matter

## Testing
- `npm run build`
- `npm run typecheck`
- `npm start` *(fails: The NOTION_TOKEN environment variable is not set.)*

------
https://chatgpt.com/codex/tasks/task_b_68a2c9dbbc30832db5089cba1b583756