### PR TITLE
Enhance dark mode table colors

### DIFF
--- a/themes/github-style/static/css/dark.css
+++ b/themes/github-style/static/css/dark.css
@@ -487,14 +487,14 @@
   --color-bg-info: rgba(56, 139, 253, 0.1);
   --color-bg-info-inverse: #388bfd;
   --color-bg-overlay: #21262d;
-  --color-bg-primary: #0f1419;
+  --color-bg-primary: #161b22;
   --color-bg-secondary: #131922;
   --color-bg-success: rgba(46, 160, 67, 0.1);
   --color-bg-success-inverse: #2ea043;
   --color-bg-table-of-contents-container: rgb(28, 33, 40);
   --color-bg-table-of-contents-option-selected: rgb(31, 111, 235);
   --color-fg-table-of-contents-option-selected: var(--color-text-primary);
-  --color-bg-tertiary: #0d1117;
+  --color-bg-tertiary: #0f1117;
   --color-bg-warning: rgba(187, 128, 9, 0.1);
   --color-bg-warning-inverse: #bb8009;
   --color-blankslate-icon: #535c66;

--- a/themes/github-style/static/css/github-style.css
+++ b/themes/github-style/static/css/github-style.css
@@ -211,3 +211,11 @@ body {
   margin-top: 0;
   margin-bottom: 1.2em;
 }
+
+[data-color-mode="dark"] .markdown-body table {
+  background-color: var(--color-bg-primary);
+}
+
+[data-color-mode="dark"] .markdown-body table tr:nth-child(2n) {
+  background-color: var(--color-bg-tertiary);
+}


### PR DESCRIPTION
## Summary
- adjust `--color-bg-primary` and `--color-bg-tertiary` to distinct dark hues
- apply dark theme table backgrounds using those variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2d89b5460832daa031e2c25b3a14b