### PR TITLE
feat: tweak code block styling

### DIFF
--- a/themes/github-style/static/css/dark.css
+++ b/themes/github-style/static/css/dark.css
@@ -703,7 +703,7 @@
   --color-label-warning-text: #e3b341;
   --color-logo-subdued: #30363d;
   --color-markdown-blockquote-border: #3b434b;
-  --color-markdown-code-bg: #0d1117;
+  --color-markdown-code-bg: #161b22;
   --color-markdown-frame-border: #3b434b;
   --color-markdown-table-border: #3b434b;
   --color-markdown-table-tr-border: #272c32;

--- a/themes/github-style/static/css/syntax.css
+++ b/themes/github-style/static/css/syntax.css
@@ -52,6 +52,8 @@ code .s {
 
 pre {
   background-color: var(--color-markdown-code-bg);
+  border-radius: 6px;
+  padding: 0.75em 1em;
 }
 
 pre code {


### PR DESCRIPTION
## Summary
- lighten dark theme code block background
- add border radius and padding to code blocks for readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2d89a9824832da980e9c6ed512afc