### PR TITLE
feat: adjust dark mode styling

### DIFF
--- a/themes/github-style/static/css/github-style.css
+++ b/themes/github-style/static/css/github-style.css
@@ -194,6 +194,8 @@ body {
 [data-color-mode="dark"] body {
   font-size: 16px;
   line-height: 1.7;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
 }
 
 [data-color-mode="dark"] h1,
@@ -205,6 +207,7 @@ body {
   line-height: 1.3;
   margin-top: 1.6em;
   margin-bottom: 0.8em;
+  color: var(--color-text-primary);
 }
 
 [data-color-mode="dark"] p {


### PR DESCRIPTION
## Summary
- ensure dark-mode body uses primary text and background colors
- apply primary text color to headings in dark mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2d899c568832da9eb74af0a72106c