### PR TITLE
Configure Gitalk OAuth proxy

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -32,6 +32,7 @@ pygmentsUseClasses = true
     pagerDirection = "last"  # 댓글 정렬 방향
     createIssueManually = true  # 관리자가 수동으로 이슈 생성
     distractionFreeMode = false  # 집중 모드 비활성화
+    proxy = "https://cors-anywhere.azm.workers.dev/https://github.com/login/oauth/access_token"
 
   [[params.links]]
     title = "Email"


### PR DESCRIPTION
## Summary
- add Gitalk proxy URL so OAuth requests bypass CORS issues

## Testing
- `npm run build`
- `npm run typecheck`
- `hugo`
- `npm run server` *(fails: REF_NOT_FOUND page not found, preventing manual login test)*

------
https://chatgpt.com/codex/tasks/task_b_68a2dcd72870832d851e3012b5dce479